### PR TITLE
Change bootstrap url to cdn

### DIFF
--- a/src/Zicht/Bundle/AdminBundle/Resources/views/Security/login.html.twig
+++ b/src/Zicht/Bundle/AdminBundle/Resources/views/Security/login.html.twig
@@ -5,7 +5,7 @@
 
         <title>Zicht CMS | login</title>
 
-        <link rel="stylesheet" href="{{ asset('bundles/sonataadmin/vendor/bootstrap/dist/css/bootstrap.min.css') }}">
+        <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
         <link rel="stylesheet" href="{{ asset('bundles/zichtadmin/style/login.css') }}">
     </head>
     <body>


### PR DESCRIPTION
In the latest sonata-project/admin-bundle (>= 3.0.0) the bootstrap is on a different location. So therefor we now link to the cdn, so we can always have a bootstrap include and have no dependency on sonata for the styling ^^