### PR TITLE
Fixed custom sorting issue in Tree Admin caused by sonata-project/doctrine-orm-admin-bundle 3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 5.1.2 - 2020-05-04
 ### Fixed
 - Prefixed the Admin bundle Controller routes with /admin to place /quick-list within the admin path and prevent unauthorised user to request the quick list
+- Fixed custom sorting issue in Tree Admin caused by sonata-project/doctrine-orm-admin-bundle 3.15
 
 ## 5.1.1 - 2020-04-29
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7",
         "symfony/symfony": "^3.4",
         "doctrine/doctrine-bundle": "^1",
-        "sonata-project/doctrine-orm-admin-bundle": "^3",
+        "sonata-project/doctrine-orm-admin-bundle": "^3.15",
         "zicht/framework-extra-bundle": "^8.0",
         "sensio/framework-extra-bundle": ">=3.0 <6"
     },

--- a/src/Zicht/Bundle/AdminBundle/Admin/TreeAdmin.php
+++ b/src/Zicht/Bundle/AdminBundle/Admin/TreeAdmin.php
@@ -5,14 +5,15 @@
 
 namespace Zicht\Bundle\AdminBundle\Admin;
 
+use Doctrine\Common\Collections\Criteria;
 use Sonata\AdminBundle\Admin\Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Zicht\Bundle\AdminBundle\Sonata\Datagrid\CustomSortProxyQuery;
 use Zicht\Bundle\FrameworkExtraBundle\Form\ParentChoiceType;
 
 /**
@@ -41,12 +42,13 @@ class TreeAdmin extends Admin
                 ->from($this->getClass(), 'n');
 
             if ($cmd->hasField('root')) {
-                $queryBuilder->orderBy('n.root, n.lft');
+                $queryBuilder->orderBy('n.root', Criteria::ASC);
+                $queryBuilder->addOrderBy('n.lft', Criteria::ASC);
             } else {
-                $queryBuilder->orderBy('n.lft');
+                $queryBuilder->orderBy('n.lft', Criteria::ASC);
             }
 
-            return new ProxyQuery($queryBuilder);
+            return new CustomSortProxyQuery($queryBuilder);
         }
         return parent::createQuery($context);
     }

--- a/src/Zicht/Bundle/AdminBundle/Sonata/Datagrid/CustomSortProxyQuery.php
+++ b/src/Zicht/Bundle/AdminBundle/Sonata/Datagrid/CustomSortProxyQuery.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @copyright Zicht Online <https://zicht.nl>
+ */
+
+namespace Zicht\Bundle\AdminBundle\Sonata\Datagrid;
+
+use Doctrine\Common\Collections\Criteria;
+use Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery;
+
+/**
+ * Allow custom sorting to go before the sorting chosen by the user in the admin datagrid (list view)
+ * @see \Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQuery
+ */
+class CustomSortProxyQuery extends ProxyQuery
+{
+    /** {@inheritDoc} */
+    public function execute(array $params = [], $hydrationMode = null)
+    {
+        if (!$this->getSortBy() || 0 === count($this->queryBuilder->getDQLPart('orderBy'))) {
+            return parent::execute($params, $hydrationMode);
+        }
+
+        // Save originals
+        $queryBuilderOriginal = clone $this->queryBuilder;
+        $sortByOriginal = $this->sortBy;
+        $sortOrderOriginal = $this->sortOrder;
+
+        // Reset
+        $orderByDQLPart = $this->queryBuilder->getDQLPart('orderBy');
+        $this->queryBuilder->resetDQLPart('orderBy');
+
+        // Trick the Sonata Datagrid ProxyQuery into respecting our sorting
+        /** @var \Doctrine\ORM\Query\Expr\OrderBy $primarySort */
+        $primarySort = array_shift($orderByDQLPart);
+        if ($primarySort->count() > 0) {
+            $sortSplit = explode(' ', $primarySort->getParts()[0], 2);
+            $this->sortBy = $sortSplit[0];
+            $this->sortOrder = $sortSplit[1] ?? Criteria::ASC;
+        }
+
+        foreach ($orderByDQLPart as $orderBy) {
+            $this->queryBuilder->addOrderBy($orderBy);
+        }
+        $this->queryBuilder->addOrderBy($sortByOriginal, $sortOrderOriginal);
+
+        // Execute
+        $results = parent::execute($params, $hydrationMode);
+
+        // Restore originals
+        $this->queryBuilder = $queryBuilderOriginal;
+        $this->sortBy = $sortByOriginal;
+        $this->sortOrder = $sortOrderOriginal;
+
+        return $results;
+    }
+
+}


### PR DESCRIPTION
Komt door:

> sonata-project/doctrine-orm-admin-bundle 3.15.0 - 2020-03-16
> Fixed
> * The _sort_by_ datagrid value is properly applied before any custom orderBy.

Oftewel, de hiërarchie wordt als "platte" lijst weergegeven gesorteerd op ID (default sortering), omdat door deze fix de ID sortering eerst wordt geplaatst:
onze custom order by regels worden opgehaald, order by wordt gecleared, dan wordt eerste de default sortering toegepast en dan worden de custom sorteringen terug geplaatst.