### PR TITLE
Fix quick list admin route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.10 - 2020-05-04
+- Prefixed the Admin bundle Controller routes with /admin to place /quick-list within the admin path and prevent unauthorised user to request the quick list
+
 ## 3.4.9
 - Fix the translation for the duplicate flash_message
 

--- a/src/Zicht/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Zicht/Bundle/AdminBundle/Resources/config/routing.yml
@@ -1,4 +1,7 @@
-zicht_admin:            { resource: "@ZichtAdminBundle/Controller" }
+zicht_admin:
+    resource: "@ZichtAdminBundle/Controller"
+    prefix: /admin
+
 zicht_admin_redirect:
     path: /admin
     path: /admin/


### PR DESCRIPTION
Prefixed the Admin bundle Controller routes with /admin to place
/quick-list within the admin path and prevent unauthorised user to
request the quick list