### PR TITLE
Fix missing command name of ExportSqlCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 5.2.1 - 2020-06-03
 ### Fixed
 - Fixed missing name for ExportSqlCommand
+- Fixed `Sonata\Export\Writer\TypedWriterInterface` use statement in `src/Zicht/Bundle/AdminBundle/Exporter/Writer/TwigWriter.php`
 
 ## 5.2.0 - 2020-05-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 
+## 5.2.1 - 2020-06-03
+### Fixed
+- Fixed missing name for ExportSqlCommand
+
 ## 5.2.0 - 2020-05-14
 ### Fixed
 - Fixed composer.json (psr-4 autoloader, dependencies), fixed linter errors, fixed tests

--- a/src/Zicht/Bundle/AdminBundle/Command/ExportSqlCommand.php
+++ b/src/Zicht/Bundle/AdminBundle/Command/ExportSqlCommand.php
@@ -34,6 +34,7 @@ class ExportSqlCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
+            ->setName('zicht:export:sql')
             ->addArgument('sql', InputArgument::REQUIRED, 'The raw SELECT query.')
             ->addOption('file', 'f', InputOption::VALUE_REQUIRED, 'File to write to, if none given it will use stdout.')
             ->addOption('type', 't', InputOption::VALUE_REQUIRED, 'The export type.', 'xls')

--- a/src/Zicht/Bundle/AdminBundle/Command/ExportSqlCommand.php
+++ b/src/Zicht/Bundle/AdminBundle/Command/ExportSqlCommand.php
@@ -18,6 +18,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ExportSqlCommand extends ContainerAwareCommand
 {
+    /** @var string */
+    protected static $defaultName = 'zicht:export:sql';
+
     /** @var string[] */
     protected $typeMapping = [
         'xls' => 'Exporter\\Writer\\XlsWriter',
@@ -34,7 +37,6 @@ class ExportSqlCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('zicht:export:sql')
             ->addArgument('sql', InputArgument::REQUIRED, 'The raw SELECT query.')
             ->addOption('file', 'f', InputOption::VALUE_REQUIRED, 'File to write to, if none given it will use stdout.')
             ->addOption('type', 't', InputOption::VALUE_REQUIRED, 'The export type.', 'xls')

--- a/src/Zicht/Bundle/AdminBundle/Exporter/Writer/TwigWriter.php
+++ b/src/Zicht/Bundle/AdminBundle/Exporter/Writer/TwigWriter.php
@@ -5,7 +5,7 @@
 
 namespace Zicht\Bundle\AdminBundle\Exporter\Writer;
 
-use Exporter\Writer\TypedWriterInterface;
+use Sonata\Exporter\Writer\TypedWriterInterface;
 
 class TwigWriter implements TypedWriterInterface
 {
@@ -41,7 +41,7 @@ class TwigWriter implements TypedWriterInterface
     /**
      * {@inheritDoc}
      */
-    public function getDefaultMimeType()
+    public function getDefaultMimeType(): string
     {
         return 'text/plain';
     }
@@ -49,7 +49,7 @@ class TwigWriter implements TypedWriterInterface
     /**
      * {@inheritDoc}
      */
-    public function getFormat()
+    public function getFormat(): string
     {
         return 'text';
     }


### PR DESCRIPTION
This PR will fix the following error (discovered when I used `composer update` in a project which uses this bundle):

```
[WARNING] Some commands could not be registered:                                                                                                                                                                                          
The command defined in "Zicht\Bundle\AdminBundle\Command\ExportSqlCommand" cannot have an empty name.
```

It disappeared in https://github.com/zicht/admin-bundle/commit/dd708105263c470c72f3c560d65e647ca3b3f784#diff-904cf2ad61d6f19d0f0c24dfe64317eaL40 but I think this was not intended.