### PR TITLE
Duplicate and override object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added|Changed|Deprecated|Removed|Fixed|Security
+Nothing so far
+
+## 6.1.0 - 2020-10-29
+### Added
+- Added the ObjectDuplicateEvent (as a service) in order for other bundles to listen to this event (dipatched in the CRUDController)
+- Added an overrideAction in the CRUDController to override content of one object to another
+- Added a new form type: OverrideObjectType.php
 
 ## 6.0.4 - 2020-10-20
 ### Removed

--- a/README.md
+++ b/README.md
@@ -29,6 +29,70 @@ zicht_admin
             - a.site.nl
 ```
 
+## Duplicate entities
+To duplicate an entity, add the following code:
+1. In the admin of the entity you want to duplicate, add the route:
+    ```
+    /**
+     * {@inheritDoc}
+     */
+    protected function configureRoutes(RouteCollection $collection)
+    {
+        $collection->add('duplicate');
+    }
+    ```
+
+2. In `templates/bundles/SonataAdminBundle/CRUD/edit.html.twig` add the duplicate button:
+    ```
+    {% if admin.hasroute('duplicate') %}
+        <a class="btn btn-info" href="{{ admin.generateObjectUrl('duplicate', object) }}">{{ 'admin.duplicate.text_button'|trans }}</a>
+    {% endif %}
+    ```
+For an example, see https://github.com/zicht/zestor.nl/pull/155/files
+
+## Override entities
+To also override the entities content (after duplication, see section above), add the following code:
+1. Add the route in the admin so the configureRoute method becomes:
+   ```
+   /**
+    * {@inheritDoc}
+    */
+   protected function configureRoutes(RouteCollection $collection)
+   {
+       $collection->add('duplicate');
+       $collection->add('override');
+   }
+   ```
+2. In the entity create the field `copiedFrom` (and its getter and setter).
+   ```
+   /**
+    * @var Page
+    * @ORM\ManyToOne(targetEntity="App\Entity\Page")
+    * @ORM\JoinColumn(referencedColumnName="id", onDelete="SET NULL")
+    */
+   private $copiedFrom;
+   ```
+3. In the admin of the entity, add the override-button:
+    ```
+    if ($this->getSubject()->getCopiedFrom()) {
+        $formMapper
+            ->tab('admin.tab.schedule_publication')
+                ->add(
+                    'copiedFrom',
+                    OverrideObjectType::class,
+                    [
+                        'required' => false, 
+                        'object' => $this->getSubject(),
+                        'help' => $this->trans('admin.help.override', ['%copied_from%' => $this->getSubject()->getCopiedFrom()])
+                    ]
+                )
+                ->end()
+            ->end();
+    }
+    ```
+
+For an example, see https://github.com/zicht/zestor.nl/pull/155/files
+
 # Maintainers
 * Boudewijn Schoon <boudewijn@zicht.nl>
 * Erik Trapman <erik@zicht.nl>

--- a/src/Event/AdminEvents.php
+++ b/src/Event/AdminEvents.php
@@ -14,4 +14,6 @@ final class AdminEvents
      * Events of this type are added to the admin menu
      */
     const MENU_EVENT = 'zicht_admin.menu';
+    
+    const OBJECT_DUPLICATE_EVENT = 'zicht_admin.object_duplicate';
 }

--- a/src/Event/ObjectDuplicateEvent.php
+++ b/src/Event/ObjectDuplicateEvent.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @copyright Zicht Online <https://zicht.nl>
+ */
+
+namespace Zicht\Bundle\AdminBundle\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class ObjectDuplicateEvent extends Event
+{
+    /** @var object */
+    private $oldObject;
+
+    /** @var object */
+    private $newObject;
+
+    /**
+     * @param object $oldObject
+     * @param object $newObject
+     */
+    public function __construct($oldObject, $newObject)
+    {
+        $this->oldObject = $oldObject;
+        $this->newObject = $newObject;
+    }
+    
+    /**
+     * @return object
+     */
+    public function getOldObject()
+    {
+        return $this->oldObject;
+    }
+
+    /**
+     * @return object
+     */
+    public function getNewObject()
+    {
+        return $this->newObject;
+    }
+}

--- a/src/Form/OverrideObjectType.php
+++ b/src/Form/OverrideObjectType.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @copyright Zicht Online <https://www.zicht.nl>
+ */
+namespace Zicht\Bundle\AdminBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * A type utilizing the override functionality.
+ */
+class OverrideObjectType extends AbstractType
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+        $resolver->setRequired(['object']);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        parent::finishView($view, $form, $options);
+        $view->vars['object'] = $options['object'];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'zicht_override_object';
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -41,6 +41,9 @@
         <service id="zicht_admin.form.date_picker" class="Zicht\Bundle\AdminBundle\Form\DatePickerType">
             <tag name="form.type" alias="zicht_date_picker"/>
         </service>
+        <service id="zicht_admin.form.override_object" class="Zicht\Bundle\AdminBundle\Form\OverrideObjectType">
+            <tag name="form.type" alias="zicht_override_object"/>
+        </service>
 
         <service id="Zicht\Bundle\AdminBundle\AdminMenu\EventPropagationBuilder">
             <argument type="service" id="request_stack"/>

--- a/src/Resources/translations/admin.en.yml
+++ b/src/Resources/translations/admin.en.yml
@@ -1,0 +1,15 @@
+admin:
+    duplicate:
+        title_format: '[COPY] - %title%'
+    help:
+        override: Click on the button above to override the original entity <strong>%copied_from%</strong> with the current entity
+    override:
+        text_button: Override
+    sonata_flash:
+        duplicate_success: The entity has been successfully duplicated
+        override_success: The entity has been successfully overwritten
+form:
+    label_copied_from: Override entity
+zicht_quicklist:
+    autocomplete_type:
+        search_placeholder: Search...

--- a/src/Resources/translations/admin.nl.yml
+++ b/src/Resources/translations/admin.nl.yml
@@ -1,3 +1,15 @@
+admin:
+    duplicate:
+        title_format: '[KOPIE] - %title%'
+    help:
+        override: Klik op bovenstaande button om de originele entiteit <strong>%copied_from%</strong> te overschrijven met de huidige entiteit
+    override:
+        text_button: Overschrijven
+    sonata_flash:
+        duplicate_success: De entiteit is succesvol gedupliceerd
+        override_success: De entiteit is succesvol overschreven
+form:
+    label_copied_from: Entiteit overschrijven
 zicht_quicklist:
     autocomplete_type:
         search_placeholder: Zoeken...

--- a/src/Resources/views/form_theme.html.twig
+++ b/src/Resources/views/form_theme.html.twig
@@ -1,3 +1,5 @@
+{% trans_default_domain 'admin' %}
+
 {% block zicht_quicklist_autocomplete_widget %}
     {# TODO make sure somehow that this script gets loaded only once #}
     <script type="text/javascript" src="{{ asset('bundles/zichtadmin/javascript/autocomplete.js') }}"></script>
@@ -70,4 +72,8 @@
             </script>
         </li>
     </ul>
+{% endblock %}
+
+{% block zicht_override_object_widget %}
+    <a class="btn btn-info" href="{{ sonata_admin.admin.generateObjectUrl('override', object) }}">{{ 'admin.override.text_button'|trans }}</a>
 {% endblock %}


### PR DESCRIPTION
This code goes together with https://github.com/zicht/zestor.nl/pull/155 and https://github.com/zicht/page-bundle/pull/68. The purpose of this all is to be able to copy a page, to fill the copied page with new content end then to override the content of the old page with the new content. This way people can already prepare changes to a page and view these changes, without putting the changes live immediately .
