### PR TITLE
Add Buttons form type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added|Changed|Deprecated|Removed|Fixed|Security
+Nothing so far
+
+## 6.2.0 - 2021-03-08
+### Added
+- Added the generic `ButtonType` form type to be able to add buttons to an (inline) edit form
 ### Changed
 - Changed deprecated `spaceless` into `apply spaceless` in Twig template
-### Added|Changed|Deprecated|Removed|Fixed|Security
-Nothing else so far
 
 ## 6.1.2 - 2021-01-08
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ sonata_admin:
 ```
 
 ## Override Menu-events to supply other hosts
-Add the following configuration to `config/zicht_admin.yml` to override the `AdminEvents::MENU_EVENT` 
+Add the following configuration to `config/zicht_admin.yml` to override the `AdminEvents::MENU_EVENT`
 and alter the url to a match in the list.
 
 ```yaml
@@ -79,11 +79,17 @@ To also override the entities content (after duplication, see section above), ad
             ->tab('admin.tab.schedule_publication')
                 ->add(
                     'copiedFrom',
-                    OverrideObjectType::class,
+                    ButtonType::class,
                     [
-                        'required' => false, 
-                        'object' => $this->getSubject(),
-                        'help' => $this->trans('admin.help.override', ['%copied_from%' => $this->getSubject()->getCopiedFrom()])
+                        'required' => false,
+                        'help' => $this->trans('admin.help.override', ['%copied_from%' => $this->getSubject()->getCopiedFrom()]),
+                        'buttons' => [
+                            'override' => [
+                                'label' => 'admin.override.text_button',
+                                'style' => 'info',
+                                'route' => 'override',
+                            ],
+                        ],
                     ]
                 )
                 ->end()

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "sonata-project/doctrine-orm-admin-bundle": "^3.15",
         "zicht/framework-extra-bundle": "^9",
         "sensio/framework-extra-bundle": "^5",
-        "twig/twig": "^2.7 || ^3"
+        "twig/twig": "^2.9 || ^3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5",

--- a/src/Form/ButtonsType.php
+++ b/src/Form/ButtonsType.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Zicht Online <https://zicht.nl>
+ */
+
+namespace Zicht\Bundle\AdminBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ButtonsType extends AbstractType
+{
+    /**
+     * Option 'buttons' should be an array of buttons. Each button can have the options as show below.
+     * Add a field with `'mapped' => false` to not map the buttons to any field of your subject.
+     * @example:
+     *   ->add(
+     *       '_action',
+     *       ButtonsType::class,
+     *       [
+     *           'mapped' => false,
+     *           'required' => false,
+     *           'buttons' => [
+     *               'key' => [
+     *                  // Button appearance options, all optional. Will fall back to default values when omitted.
+     *                   'label' => 'action_edit', # Optional. If not specified, the 'key' will be used as label
+     *                   'label_translation_domain' => 'SonataAdminBundle', # Optional. Will take translation domain of admin when left out
+     *                   'style' => 'danger', # Optional. Sonata button style (e.g. 'default' [= default], 'primary', 'success', 'info', 'danger', 'warning')
+     *                   'size' => 'sm', # Optional. Sonata button size. Skip for default size, otherwise pick 'xs', 'sm' or 'lg'.
+     *                   'icon' => 'pencil', # Optional. Sonata FA icon style
+     *                   'disabled' => 'true', # Optional. Set 'disabled' attribute on which Sonata applies a disabled style
+     *                  // Button action/target options. One of either of these is required
+     *                   'route' => 'edit', # Admin route to use to render the button URL, OR...
+     *                   'url' => '/admin/dashboard', # ... Absolute or relative URL to use
+     *               ],
+     *           ],
+     *       ]
+     *   )
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setRequired(['buttons']);
+        $resolver->setAllowedTypes('buttons', 'array[]');
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $view->vars['buttons'] = $options['buttons'];
+        $view->vars['admin'] = $view->vars['sonata_admin']['admin'];
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'zicht_admin_buttons';
+    }
+}

--- a/src/Form/OverrideObjectType.php
+++ b/src/Form/OverrideObjectType.php
@@ -12,6 +12,32 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * A type utilizing the override functionality.
+ *
+ * @deprecated Use the more generic {@see \Zicht\Bundle\AdminBundle\Form\ButtonsType}
+ *   Before, OverrideObjectType had to be passed the object explicitly,
+ *   but automatically would take the route 'override' and the translate 'admin.override.text_button':
+ *     ```
+ *     ->add(
+ *         'copiedFrom',
+ *         OverrideObjectType::class,
+ *         ['object' => $this->getSubject()]
+ *     )
+ *     ```
+ *   Now, ButtonsType should be passed the options for the button, but automatically takes
+ *   the admin's subject as the target object:
+ *     ```
+ *     ->add(
+ *         'copiedFrom',
+ *         ButtonsType::class,
+ *         ['buttons' => [
+ *             'override' => [
+ *                 'label' => 'admin.override.text_button',
+ *                 'style' => 'info',
+ *                 'route' => 'override',
+ *             ],
+ *         ]]
+ *     )
+ *     ```
  */
 class OverrideObjectType extends AbstractType
 {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -44,6 +44,9 @@
         <service id="zicht_admin.form.override_object" class="Zicht\Bundle\AdminBundle\Form\OverrideObjectType">
             <tag name="form.type" alias="zicht_override_object"/>
         </service>
+        <service id="zicht_admin.form.buttons" class="Zicht\Bundle\AdminBundle\Form\ButtonsType">
+            <tag name="form.type" alias="zicht_buttons"/>
+        </service>
 
         <service id="Zicht\Bundle\AdminBundle\AdminMenu\EventPropagationBuilder">
             <argument type="service" id="request_stack"/>

--- a/src/Resources/views/form_theme.html.twig
+++ b/src/Resources/views/form_theme.html.twig
@@ -75,6 +75,47 @@
     </ul>
 {% endblock %}
 
-{% block zicht_override_object_widget %}
-    <a class="btn btn-info" href="{{ sonata_admin.admin.generateObjectUrl('override', object) }}">{{ 'admin.override.text_button'|trans }}</a>
+{% block zicht_override_object_widget -%}
+    {%- deprecated 'The OverrideObjectType form type is deprecated, use the ButtonsType instead.' -%}
+    {#- @see \Zicht\Bundle\AdminBundle\Form\OverrideObjectType -#}
+    {%- with {
+        admin: sonata_admin.admin,
+        buttons: {
+            'admin.override.text_button': {
+                style: 'info',
+                route: 'override',
+            },
+        }
+    } -%}
+        {{- block('zicht_admin_buttons_widget') -}}
+    {%- endwith -%}
+{%- endblock %}
+
+{% block zicht_admin_buttons_widget %}
+    {%- apply spaceless %}
+        {# @see \Zicht\Bundle\AdminBundle\Form\ButtonsType #}
+        {# @var admin \Sonata\AdminBundle\Admin\AbstractAdmin #}
+        <div class="btn-group">
+            {% for key, button in buttons %}
+                {% if (not admin.subject or admin.subject.id is empty) and not button.url|default %}
+                    {# We should create a URL through de subject, but there's no subject, so disable the button #}
+                    {% set button = button|merge({ disabled: true }) %}
+                {% endif %}
+                {% set label = button.label|default(key)|trans({}, (button.label_translation_domain|default(admin.translationDomain|default('SonataAdminBundle')))) %}
+                <a class="btn{{ button.size|default ? ' btn-' ~ button.size }} btn-{{ button.style|default('default') }}" title="{{ label }}"
+                    {%- if not button.disabled|default(false) %}
+                        {{- ' ' }}href="{{ button.url|default ?: admin.generateObjectUrl(button.route, admin.subject) }}"
+                    {%- endif -%}
+                    {%- if button.disabled|default(false) %}
+                        {{- ' ' }}disabled aria-disabled="true"
+                    {%- endif -%}
+                >
+                    {%- if button.icon|default -%}
+                        <i class="fa fa-{{ button.icon }}" aria-hidden="true"></i>&nbsp;
+                    {%- endif -%}
+                    {{- label -}}
+                </a>
+            {% endfor %}
+        </div>
+    {% endapply -%}
 {% endblock %}


### PR DESCRIPTION
### Generic form type to add buttons to an (inline) edit form

Examples:

----

_Button within an edit screen (with form label and form help text)_

![Screenshot from 2021-03-08 09-48-46](https://user-images.githubusercontent.com/2794908/110301758-c0e85280-7ff8-11eb-8e79-b5fd67e18ef7.png)

----

_Buttons within an inline admin. Here to edit the entity further in much more detail, to view the result or to delete the row/record:_

![Screenshot from 2021-03-08 10-53-31](https://user-images.githubusercontent.com/2794908/110305089-a021fc00-7ffc-11eb-804c-df197e0c86f7.png)

----

Usage example:

```php
    protected function configureFormFields(FormMapper $form): void
    {
        $form
            ->add('title')
            ->add(
                '_action',
                ButtonsType::class,
                [
                    'mapped' => false,
                    'required' => false,
                    'buttons' => [
                        'button.edit' => [
                            'route' => 'edit',
                            'icon' => 'pencil',
                            'style' => 'info',
                        ],
                    ],
                ]
            );
        }
```