### PR TITLE
Fix: Set Psr ContainerInterface as container on Controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 Nothing so far
 
+## 8.0.1 - 2022-11-11
+### Fixed
+- Set Psr ContainerInterface as container on Controllers
+
 ## 8.0.0 - 2022-10-06
 ### Added
 - Support for Symfony ^5.4

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -16,6 +16,9 @@
         <prototype namespace="Zicht\Bundle\AdminBundle\Controller\" resource="../../Controller/" exclude="../../Controller/RcController.php" autowire="true" public="true">
             <tag name="controller.service_arguments" />
             <tag name="container.service_subscriber" />
+            <call method="setContainer">
+                <argument type="service" id="Psr\Container\ContainerInterface" />
+            </call>
         </prototype>
 
         <service id="zicht_admin.event_subscriber" class="Zicht\Bundle\AdminBundle\Event\Subscriber">


### PR DESCRIPTION
Met onderstaande call wordt de complete Symfony Container (`service_container`) toegevoegd met alle gevolgen van dien:
```xml
            <call method="setContainer">
                <argument type="service" id="service_container" />
            </call>
```
![The-sonata-admin-request-fetcher-service-or-alias-has-been-removed-or-inlined-when-the-container-was-compiled](https://user-images.githubusercontent.com/2794908/201331627-5bc403a8-45a0-4523-844a-d24c3d7d6f11.png)

Met `Psr\Container\ContainerInterface` als service kan er een `ServiceLocator` worden geïnjecteerd met alleen de services waarop de class heeft gesubscribed.